### PR TITLE
Fix minor theoretical issue in wzipkin.spanImpl

### DIFF
--- a/wzipkin/span.go
+++ b/wzipkin/span.go
@@ -25,18 +25,16 @@ import (
 
 func fromZipkinSpan(span zipkin.Span) wtracing.Span {
 	return &spanImpl{
-		SpanContext: fromZipkinSpanContext(span.Context()),
-		span:        span,
+		span: span,
 	}
 }
 
 type spanImpl struct {
-	wtracing.SpanContext
 	span zipkin.Span
 }
 
 func (s *spanImpl) Context() wtracing.SpanContext {
-	return s.SpanContext
+	return fromZipkinSpanContext(s.span.Context())
 }
 
 func (s *spanImpl) Finish() {


### PR DESCRIPTION
Ensure that ths wtracing.SpanContext returned by Context() is
always constructed using the stored zipkin.Span (rather than
computing and storing once during construction). Ensures that,
if the underlying span changes, the context returned by the
struct will reflect that change.