### PR TITLE
allow the span to be tagged other than creation

### DIFF
--- a/changelog/@unreleased/pr-56.v2.yml
+++ b/changelog/@unreleased/pr-56.v2.yml
@@ -1,0 +1,5 @@
+type: improvement
+improvement:
+  description: Add tag functionality to spans that have been created
+  links:
+  - https://github.com/palantir/witchcraft-go-tracing/pull/56

--- a/wtracing/context.go
+++ b/wtracing/context.go
@@ -101,7 +101,7 @@ func (noopSpan) Context() SpanContext {
 
 func (noopSpan) Finish() {}
 
-func (noopSpan) Tag(string,string) {}
+func (noopSpan) Tag(string, string) {}
 
 // TraceIDFromContext returns the traceId associated with the span stored in the provided context. Returns an empty
 // string if no span is stored in the context.

--- a/wtracing/context.go
+++ b/wtracing/context.go
@@ -101,6 +101,8 @@ func (noopSpan) Context() SpanContext {
 
 func (noopSpan) Finish() {}
 
+func (noopSpan) Tag(string,string) {}
+
 // TraceIDFromContext returns the traceId associated with the span stored in the provided context. Returns an empty
 // string if no span is stored in the context.
 func TraceIDFromContext(ctx context.Context) TraceID {

--- a/wtracing/span.go
+++ b/wtracing/span.go
@@ -25,6 +25,11 @@ type SpanID string
 type Span interface {
 	Context() SpanContext
 
+	// Tag sets Tag with given key and value to the Span. If key already exists in
+	// the Span the value will be overridden except for error tags where the first
+	// value is persisted.
+	Tag(key string, value string)
+
 	// Finish the Span and send to Reporter.
 	Finish()
 }

--- a/wtracing/wtracingtests/tests.go
+++ b/wtracing/wtracingtests/tests.go
@@ -34,6 +34,8 @@ func (s noopFinishSpan) Context() wtracing.SpanContext {
 	return wtracing.SpanContext(s)
 }
 
+func (s noopFinishSpan) Tag(key string, value string) {}
+
 func (s noopFinishSpan) Finish() {}
 
 func RunTests(t *testing.T, provider ImplProvider) {

--- a/wtracing/wtracingtests/tests.go
+++ b/wtracing/wtracingtests/tests.go
@@ -100,6 +100,18 @@ func testWithParent(t *testing.T, tracer wtracing.Tracer) {
 		assert.Equal(t, idHexVal, string(newSpan.Context().ID))      // SpanID should also be equal to parent (because parent was not valid, this creates a new root span)
 		assert.Nil(t, newSpan.Context().ParentID)                    // ParentID should be nil
 	})
+
+	t.Run("set tag", func(t *testing.T) {
+		isSampled := true
+		testParentSpan := noopFinishSpan(wtracing.SpanContext{
+			TraceID: idHexVal,
+			Sampled: &isSampled,
+		})
+		newSpan := tracer.StartSpan("testSpan",
+			wtracing.WithParent(testParentSpan),
+		)
+		newSpan.Tag("key","value")
+	})
 }
 
 func testWithParentSpanContext(t *testing.T, tracer wtracing.Tracer) {

--- a/wzipkin/span.go
+++ b/wzipkin/span.go
@@ -37,6 +37,10 @@ func (s *spanImpl) Context() wtracing.SpanContext {
 	return fromZipkinSpanContext(s.span.Context())
 }
 
+func (s *spanImpl) Tag(key string, value string) {
+	s.span.Tag(key, value)
+}
+
 func (s *spanImpl) Finish() {
 	s.span.Finish()
 }


### PR DESCRIPTION
## Before this PR
No ability to tag a span after its creation.

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Add tag functionality to spans that have been created.
==COMMIT_MSG==

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palantir/witchcraft-go-tracing/56)
<!-- Reviewable:end -->
