### PR TITLE
Fix: Allow B3 headers that carry only sampling state

### DIFF
--- a/wtracing/propagation/b3/extractor.go
+++ b/wtracing/propagation/b3/extractor.go
@@ -23,10 +23,15 @@ import (
 )
 
 // SpanExtractor returns a SpanExtractor that returns a wtracing.SpanContext based on the header content of the provided
-// *http.Request. If the values in the provided header do not constitute a valid SpanContext (for example, if it is
-// missing a TraceID or SpanID, has an unsupported "Sampled" value, etc.), the "Err" field of the returned SpanContext
-// will be non-nil and will contain an error that describes why the values were invalid. However, even if the "Err"
-// field is set, all of the values that could be extracted from the header and set on the returned context.
+// *http.Request. If the values in the provided header do not constitute a valid SpanContext, for example if it has a
+// SpanID but no TraceID, or an unsupported Sampled value, the Err field of the returned SpanContext will be non-nil
+// and will contain an error that describes why the values were invalid. However, even if the Err field is set, all
+// of the values that could be extracted from the header are still set on the returned context.
+//
+// A request is allowed to leave out TraceID and SpanID entirely and carry only a sampling decision, for example a
+// lone X-B3-Sampled header. The B3 propagation spec treats that as valid, see
+// https://github.com/openzipkin/b3-propagation#sampling-state, so it is not treated as an error here either, unless
+// a ParentSpanId is also present, since a parent span cannot exist without a trace to belong to.
 func SpanExtractor(req *http.Request) wtracing.SpanExtractor {
 	return func() wtracing.SpanContext {
 		var sc wtracing.SpanContext
@@ -34,31 +39,32 @@ func SpanExtractor(req *http.Request) wtracing.SpanExtractor {
 		errSafeParams := make(map[string]any)
 
 		traceID := strings.ToLower(req.Header.Get(b3TraceID))
-		if traceID == "" {
-			errMsgs = append(errMsgs, "TraceID missing")
-		}
 		sc.TraceID = wtracing.TraceID(traceID)
 
 		spanID := strings.ToLower(req.Header.Get(b3SpanID))
-		if spanID == "" {
-			errMsgs = append(errMsgs, "SpanID missing")
-		}
 		sc.ID = wtracing.SpanID(spanID)
 
-		var parentIDVal *wtracing.SpanID
-		if parentID := strings.ToLower(req.Header.Get(b3ParentSpanID)); parentID != "" {
-			if traceID == "" || spanID == "" {
-				if traceID == "" && spanID == "" {
-					errMsgs = append(errMsgs, "ParentID present but TraceID and SpanID missing")
-				} else if traceID == "" {
-					errMsgs = append(errMsgs, "ParentID present but TraceID missing")
-				} else {
-					errMsgs = append(errMsgs, "ParentID present but SpanID missing")
-				}
-			}
-			parentIDVal = (*wtracing.SpanID)(&parentID)
+		parentID := strings.ToLower(req.Header.Get(b3ParentSpanID))
+		if parentID != "" {
+			sc.ParentID = (*wtracing.SpanID)(&parentID)
 		}
-		sc.ParentID = parentIDVal
+
+		switch {
+		case traceID == "" && spanID == "":
+			if parentID != "" {
+				errMsgs = append(errMsgs, "TraceID missing", "SpanID missing", "ParentID present but TraceID and SpanID missing")
+			}
+		case traceID == "":
+			errMsgs = append(errMsgs, "TraceID missing")
+			if parentID != "" {
+				errMsgs = append(errMsgs, "ParentID present but TraceID missing")
+			}
+		case spanID == "":
+			errMsgs = append(errMsgs, "SpanID missing")
+			if parentID != "" {
+				errMsgs = append(errMsgs, "ParentID present but SpanID missing")
+			}
+		}
 
 		var sampledVal *bool
 		switch sampledHeader := strings.ToLower(req.Header.Get(b3Sampled)); sampledHeader {

--- a/wtracing/propagation/b3/extractor.go
+++ b/wtracing/propagation/b3/extractor.go
@@ -49,21 +49,19 @@ func SpanExtractor(req *http.Request) wtracing.SpanExtractor {
 			sc.ParentID = (*wtracing.SpanID)(&parentID)
 		}
 
+		errMsgPrefix := ""
+		if parentID != "" {
+			errMsgPrefix = "ParentID present but "
+		}
 		switch {
 		case traceID == "" && spanID == "":
 			if parentID != "" {
-				errMsgs = append(errMsgs, "TraceID missing", "SpanID missing", "ParentID present but TraceID and SpanID missing")
+				errMsgs = append(errMsgs, errMsgPrefix+"TraceID and SpanID missing")
 			}
 		case traceID == "":
-			errMsgs = append(errMsgs, "TraceID missing")
-			if parentID != "" {
-				errMsgs = append(errMsgs, "ParentID present but TraceID missing")
-			}
+			errMsgs = append(errMsgs, errMsgPrefix+"TraceID missing")
 		case spanID == "":
-			errMsgs = append(errMsgs, "SpanID missing")
-			if parentID != "" {
-				errMsgs = append(errMsgs, "ParentID present but SpanID missing")
-			}
+			errMsgs = append(errMsgs, errMsgPrefix+"SpanID missing")
 		}
 
 		var sampledVal *bool

--- a/wtracing/propagation/b3/extractor_test.go
+++ b/wtracing/propagation/b3/extractor_test.go
@@ -52,13 +52,12 @@ func TestSpanExtractor(t *testing.T) {
 			},
 		},
 		{
-			name: "Error if both TraceID and SpanID absent",
+			name: "Sampled alone with no TraceID or SpanID is valid",
 			headerVals: map[string]string{
 				"X-B3-Sampled": "1",
 			},
 			want: wtracing.SpanContext{
 				Sampled: new(true),
-				Err:     werror.Error("TraceID missing; SpanID missing"),
 			},
 		},
 		{

--- a/wtracing/propagation/b3/extractor_test.go
+++ b/wtracing/propagation/b3/extractor_test.go
@@ -95,7 +95,7 @@ func TestSpanExtractor(t *testing.T) {
 				ID:       idHexVal,
 				ParentID: (*wtracing.SpanID)(new(otherIDHexVal)),
 				Sampled:  new(true),
-				Err:      werror.Error("TraceID missing; ParentID present but TraceID missing"),
+				Err:      werror.Error("ParentID present but TraceID missing"),
 			},
 		},
 		{
@@ -109,7 +109,7 @@ func TestSpanExtractor(t *testing.T) {
 				TraceID:  idHexVal,
 				ParentID: (*wtracing.SpanID)(new(otherIDHexVal)),
 				Sampled:  new(true),
-				Err:      werror.Error("SpanID missing; ParentID present but SpanID missing"),
+				Err:      werror.Error("ParentID present but SpanID missing"),
 			},
 		},
 		{
@@ -121,7 +121,7 @@ func TestSpanExtractor(t *testing.T) {
 			want: wtracing.SpanContext{
 				ParentID: (*wtracing.SpanID)(new(otherIDHexVal)),
 				Sampled:  new(true),
-				Err:      werror.Error("TraceID missing; SpanID missing; ParentID present but TraceID and SpanID missing"),
+				Err:      werror.Error("ParentID present but TraceID and SpanID missing"),
 			},
 		},
 		{


### PR DESCRIPTION
## Before this PR
`SpanExtractor` treated requests that omit `X-B3-TraceId` and `X-B3-SpanId` as invalid even when it contained a sampling state via `X-B3-Sampled`. Treating that case as an error causes the underlying `zipkin-go` library to discard the entire parent `SpanContext`, so a request that set `X-B3-Sampled: 1` silently fails to force a trace. The B3 spec explicitly allows sending sampling state on its own and in fact the Java tracing library (https://github.com/palantir/tracing-java) treats traceId and sampling extraction fully independently. 

See the many references to only sending sampling state in the spec: https://github.com/openzipkin/b3-propagation#sampling-state-2

## After this PR
<!-- User-facing outcomes this PR delivers go below -->
==COMMIT_MSG==
Allow B3 headers that carry only sampling state
==COMMIT_MSG==

Requests that only send `X-B3-Sampled` headers with no traceId or spanId is now treated as a valid `SpanContext` instead of an extraction error. Forced sampling is preserved and a new trace/span ID is generated matching the B3 spec.

## Possible downsides?
<!-- Please describe any way users could be negatively affected by this PR. -->

